### PR TITLE
Fix simulator imports and API mismatches

### DIFF
--- a/marketsim/__init__.py
+++ b/marketsim/__init__.py
@@ -1,4 +1,20 @@
-from .simulator.sampled_arrival_simulator_custom import SimulatorSampledArrivalCustom
+"""Top level package for :mod:`marketsim`.
+
+The original package initialised a number of heavy submodules eagerly.  Two
+problems followed from that approach:
+
+* ``SimulatorSampledArrivalCustom`` was re-exported even though the
+  corresponding module is not present in the repository, which caused
+  ``ImportError`` during package import; and
+* importing deep modules while the package was still initialising made it easy
+  to trigger circular import issues when those modules relied on absolute
+  ``marketsim.`` imports.
+
+To keep ``import marketsim`` lightweight and robust we only perform the
+relatively small re-exports that are guaranteed to exist.  The sampled arrival
+simulator remains available from ``marketsim.simulator``.
+"""
+
 from .simulator.simulator import Simulator
 from .market.market import Market
 from .fourheap.fourheap import FourHeap
@@ -7,7 +23,6 @@ from .fourheap.order_queue import OrderQueue
 __version__ = "0.1.0"
 
 __all__ = [
-    "SimulatorSampledArrivalCustom",
     "Simulator",
     "Market",
     "FourHeap",

--- a/marketsim/agent/agent.py
+++ b/marketsim/agent/agent.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
-from marketsim.fourheap.order import Order
 from typing import List
+
+from ..fourheap.order import Order
 
 
 class Agent(ABC):

--- a/marketsim/agent/hbl_agent.py
+++ b/marketsim/agent/hbl_agent.py
@@ -1,14 +1,16 @@
 import random
 import sys
-import scipy as sp
-import numpy as np
-from agent.agent import Agent
-from market.market import Market
-from fourheap.order import Order
-from private_values.private_values import PrivateValues
-from fourheap.constants import BUY, SELL
 from typing import List
+
+import numpy as np
+import scipy as sp
 from fastcubicspline import FCS
+
+from ..market.market import Market
+from ..fourheap.order import Order
+from ..private_values.private_values import PrivateValues
+from ..fourheap.constants import BUY, SELL
+from .agent import Agent
 
 
 class HBLAgent(Agent):

--- a/marketsim/agent/zero_intelligence_agent.py
+++ b/marketsim/agent/zero_intelligence_agent.py
@@ -1,11 +1,13 @@
 import random
-from marketsim.agent.agent import Agent
-from marketsim.market.market import Market
-from marketsim.fourheap.order import Order
-from marketsim.private_values.private_values import PrivateValues
-from marketsim.fourheap.constants import BUY, SELL
 from typing import List
+
 import numpy as np
+
+from ..market.market import Market
+from ..fourheap.order import Order
+from ..private_values.private_values import PrivateValues
+from ..fourheap.constants import BUY, SELL
+from .agent import Agent
 
 
 class ZIAgent(Agent):

--- a/marketsim/fourheap/test_order.py
+++ b/marketsim/fourheap/test_order.py
@@ -1,6 +1,6 @@
 import pytest
 
-from order import Order  # Assuming order.py is the name of the file containing your Order class
+from marketsim.fourheap.order import Order
 
 
 def test_creation():

--- a/marketsim/fourheap/test_order_queue.py
+++ b/marketsim/fourheap/test_order_queue.py
@@ -1,7 +1,7 @@
 import pytest
 
-from order import Order
-from order_queue import OrderQueue
+from marketsim.fourheap.order import Order
+from marketsim.fourheap.order_queue import OrderQueue
 
 
 def test_order_queue_operations():

--- a/marketsim/simulator/__init__.py
+++ b/marketsim/simulator/__init__.py
@@ -1,5 +1,6 @@
-from marketsim.simulator.simulator import Simulator
-from marketsim.simulator.sampled_arrival_simulator import SimulatorSampledArrival
-from marketsim.simulator.sampled_arrival_simulator_custom import SimulatorSampledArrivalCustom
+"""Simulator subpackage exports."""
 
-__all__ = ['Simulator', 'SimulatorSampledArrival', 'SimulatorSampledArrivalCustom']
+from .simulator import Simulator
+from .sampled_arrival_simulator import SimulatorSampledArrival
+
+__all__ = ["Simulator", "SimulatorSampledArrival"]

--- a/marketsim/simulator/reward_model_builder.py
+++ b/marketsim/simulator/reward_model_builder.py
@@ -12,9 +12,9 @@ import torch.optim as optim
 from torch.utils.data import DataLoader, TensorDataset
 from tqdm import tqdm
 
-from marketsim.simulator.sampled_arrival_simulator import SimulatorSampledArrival
-from marketsim.agent.reward_model_agent import RewardModelAgent
-from marketsim.simulator.reward_model_data_collector import RewardModelDataCollector
+from .sampled_arrival_simulator import SimulatorSampledArrival
+from ..agent.reward_model_agent import RewardModelAgent
+from .reward_model_data_collector import RewardModelDataCollector
 
 # Set random seeds for reproducibility
 random.seed(42)

--- a/marketsim/simulator/sampled_arrival_simulator.py
+++ b/marketsim/simulator/sampled_arrival_simulator.py
@@ -1,14 +1,12 @@
-import random
-from fourheap.constants import BUY, SELL
-from market.market import Market
-from fundamental.lazy_mean_reverting import LazyGaussianMeanReverting
-from agent.zero_intelligence_agent import ZIAgent
-from agent.hbl_agent import HBLAgent
-import torch.distributions as dist
-import torch
 from collections import defaultdict
 
+import torch
+import torch.distributions as dist
 
+from ..market.market import Market
+from ..fundamental.lazy_mean_reverting import LazyGaussianMeanReverting
+from ..agent.zero_intelligence_agent import ZIAgent
+from ..agent.hbl_agent import HBLAgent
 class SimulatorSampledArrival:
     def __init__(self,
                  num_background_agents: int,

--- a/marketsim/simulator/simulator.py
+++ b/marketsim/simulator/simulator.py
@@ -1,9 +1,10 @@
 import random
-from marketsim.fourheap.constants import BUY, SELL
-from marketsim.market.market import Market
-from marketsim.fundamental.mean_reverting import GaussianMeanReverting
-from marketsim.fundamental.lazy_mean_reverting import LazyGaussianMeanReverting
-from marketsim.agent.zero_intelligence_agent import ZIAgent
+from typing import List, Optional
+
+from ..market.market import Market
+from ..fundamental.mean_reverting import GaussianMeanReverting
+from ..fundamental.lazy_mean_reverting import LazyGaussianMeanReverting
+from ..agent.zero_intelligence_agent import ZIAgent
 
 
 
@@ -17,12 +18,16 @@ class Simulator:
                  r: float = .6,
                  shock_var=10,
                  q_max: int = 10,
-                 zi_shade: List = [10, 30]):
+                 zi_shade: Optional[List[float]] = None,
+                 pv_var: float = 5e6):
         self.num_agents = num_background_agents
         self.num_assets = num_assets
         self.sim_time = sim_time
         self.lam = lam
         self.time = 0
+
+        if zi_shade is None:
+            zi_shade = [10, 30]
 
         self.markets = []
         for _ in range(num_assets):
@@ -37,7 +42,8 @@ class Simulator:
                     agent_id=agent_id,
                     market=self.markets[0],
                     q_max=q_max,
-                    shade=[10, 30]
+                    shade=zi_shade,
+                    pv_var=pv_var
                 ))
 
     def step(self):
@@ -48,8 +54,7 @@ class Simulator:
                     if random.random() <= self.lam:
                         agent = self.agents[agent_id]
                         market.withdraw_all(agent_id)
-                        side = random.choice([BUY, SELL])
-                        orders = agent.take_action(side)
+                        orders = agent.take_action()
                         # print(f'Agent {agent.agent_id} is entering the market and makes order {order}')
                         market.add_orders(orders)
                 new_orders = market.step()

--- a/marketsim/tests/hbl_tests/hbl_test.py
+++ b/marketsim/tests/hbl_tests/hbl_test.py
@@ -2,7 +2,7 @@ from tqdm import tqdm
 import numpy as np
 import matplotlib.pyplot as plt
 import time
-from simulator.sampled_arrival_simulator import SimulatorSampledArrival
+from marketsim.simulator.sampled_arrival_simulator import SimulatorSampledArrival
 
 surpluses = []
 valueAgents = []

--- a/marketsim/tests/spoofer_tests/spoof_MM_test.py
+++ b/marketsim/tests/spoofer_tests/spoof_MM_test.py
@@ -6,18 +6,18 @@ import matplotlib.pyplot as plt
 import sys
 import os, shutil
 import pickle
-from fourheap.constants import BUY, SELL
-from wrappers.SP_wrapper import SPEnv
-from wrappers.MMSP_wrapper import MMSPEnv
-from private_values.private_values import PrivateValues
+from marketsim.fourheap.constants import BUY, SELL
+from marketsim.wrappers.SP_wrapper import SPEnv
+from marketsim.wrappers.MMSP_wrapper import MMSPEnv
+from marketsim.private_values.private_values import PrivateValues
 import torch.distributions as dist
 import torch
-from fundamental.mean_reverting import GaussianMeanReverting
+from marketsim.fundamental.mean_reverting import GaussianMeanReverting
 from stable_baselines3 import PPO
 from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv
 from stable_baselines3.common.env_util import make_vec_env
 from stable_baselines3.common.env_checker import check_env
-from custom_callback import SaveOnBestTrainingRewardCallback
+from .custom_callback import SaveOnBestTrainingRewardCallback
 import torch
 
 SIM_TIME = 10000

--- a/marketsim/tests/spoofer_tests/spoof_test.py
+++ b/marketsim/tests/spoofer_tests/spoof_test.py
@@ -3,9 +3,9 @@ import random
 import numpy as np
 import matplotlib.pyplot as plt
 import time
-from simulator.sampled_arrival_simulator import SimulatorSampledArrival
-from wrappers.SP_wrapper import SPEnv
-from private_values.private_values import PrivateValues
+from marketsim.simulator.sampled_arrival_simulator import SimulatorSampledArrival
+from marketsim.wrappers.SP_wrapper import SPEnv
+from marketsim.private_values.private_values import PrivateValues
 import torch.distributions as dist
 import torch
 


### PR DESCRIPTION
## Summary
- stop re-exporting a non-existent simulator module at package import time and rely on lightweight, safe exports
- clean up simulator construction by using package-relative imports, deferring default ZI shading and passing the required private-value variance
- switch agents, simulators, and tests to consistent package imports so downstream consumers and test runs do not trip over missing top-level modules

## Testing
- python - <<'PY'
from marketsim import Simulator

sim = Simulator(num_background_agents=2, sim_time=5)
sim.run()
print("done")
PY
- pytest *(fails: missing optional dependencies such as gymnasium and long-running notebooks in legacy tests)*

------
https://chatgpt.com/codex/tasks/task_e_68cab87bc6a8832a8f018d9c5d153b8e